### PR TITLE
Fix Italian voice detection

### DIFF
--- a/tools/phonemes_from_text.py
+++ b/tools/phonemes_from_text.py
@@ -73,7 +73,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     espeak.espeak_Initialize(AUDIO_OUTPUT_RETRIEVAL, 0, args.path.encode(), 0)
-    espeak.espeak_SetVoiceByName(args.voice.encode())
+    if espeak.espeak_SetVoiceByName(args.voice.encode()) != 0:
+        parser.error(f"voice '{args.voice}' not found in {args.path}")
 
     if args.ipa is None:
         phonememode = espeakPHONEMES_SHOW


### PR DESCRIPTION
## Summary
- flag an error if `espeak_SetVoiceByName` can't load the requested voice

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685fa57c5294832b9b1626ee36eb6e2d